### PR TITLE
chore: fix unnecessary usage of `string()` for string literals

### DIFF
--- a/examples/sui/constantinople/contracts/constantinople/sources/scripts/deploy_hook.move
+++ b/examples/sui/constantinople/contracts/constantinople/sources/scripts/deploy_hook.move
@@ -15,7 +15,7 @@
 
     public entry fun run(clock: &Clock, ctx: &mut TxContext) {
         // Create a dapp.
-        let mut dapp = dapp_system::create(string(b"constantinople"),string(b"constantinople contract"), clock , ctx);
+        let mut dapp = dapp_system::create("constantinople", "constantinople contract", clock , ctx);
         // Create schemas
         let mut entity = constantinople::entity_schema::create(ctx);
         let mut map = constantinople::map_schema::create(ctx);


### PR DESCRIPTION
I’ve removed the unnecessary `string()` wrapper around string literals in the code. In Move, strings can be passed directly as literals without needing to wrap them in a `string()` function.