### PR TITLE
fix: correct broken link to schemas config in CLI documentation

### DIFF
--- a/docs/pages/dubhe/sui/cli.mdx
+++ b/docs/pages/dubhe/sui/cli.mdx
@@ -51,7 +51,7 @@ Some commands expect a dubhe config in the same folder where the CLI is being ex
 
 ### `schemagen`
 
-Generate Store libraries from a `dubhe.config.ts` file. See the [Store Config and `schemagen` documentation](../schemas/config) in the Store section for more details.
+Generate Store libraries from a `dubhe.config.ts` file. See the [Store Config and `schemagen` documentation](./schemas/config) in the Store section for more details.
 
 ```bash
 dubhe schemagen [--config-path <path>] [--network <network>]


### PR DESCRIPTION
Fixed the broken link in docs/pages/dubhe/sui/cli.mdx that was pointing to a non-existent file path.

- Changed link from "../schemas/config" to "./schemas/config"
- The link now correctly points to the existing config.mdx file in the schemas directory
- This resolves the file not found error that was occurring during documentation build

The schemagen command documentation now properly references the Store Config and schemagen documentation.