### PR TITLE
fix: correct typos in Move modules

### DIFF
--- a/e2e/src/dubhe/sources/utils/math.move
+++ b/e2e/src/dubhe/sources/utils/math.move
@@ -98,7 +98,7 @@ module dubhe::dubhe_math {
 
     /// support 18-bit precision token
     /// if token is limited release, the total capacity around e10 (almost ten billions)
-    /// can avoid  sqrt(x*y) overflow, and at the same time avoid loss presicion
+    /// can avoid  sqrt(x*y) overflow, and at the same time avoid loss precision
     public fun safe_mul_sqrt(x: u256, y: u256): u256 {
         if (x < (u128::max_value!() as u256) && y < (u128::max_value!() as u256)) {
             sqrt_down(x * y)

--- a/examples/sui/constantinople/contracts/dubhe-framework/sources/storages/migration.move
+++ b/examples/sui/constantinople/contracts/dubhe-framework/sources/storages/migration.move
@@ -1,8 +1,8 @@
 module dubhe::storage_migration {
     use sui::dynamic_field as df;
 
-    public fun add_field<StorageType: store>(uid: &mut UID, field_name: vector<u8>, storagre_type: StorageType) {
-        df::add(uid, field_name, storagre_type);
+    public fun add_field<StorageType: store>(uid: &mut UID, field_name: vector<u8>, storage_type: StorageType) {
+        df::add(uid, field_name, storage_type);
     }
 
     public fun borrow_field<StorageType: store>(uid: &UID, field_name: vector<u8>): &StorageType {


### PR DESCRIPTION
e2e/src/dubhe/sources/utils/math.move: fixed typo in doc comment (presicion → precision).

examples/sui/constantinople/contracts/dubhe-framework/sources/storages/migration.move: corrected parameter name typo (storagre_type → storage_type) in add_field function.