### PR TITLE
feat : add supoort with dubhe config plugin

### DIFF
--- a/packages/sui-common/src/codegen/types/index.ts
+++ b/packages/sui-common/src/codegen/types/index.ts
@@ -36,6 +36,7 @@ export type DubheConfig = {
   components: Record<string, Component | MoveType | EmptyComponent>;
   resources: Record<string, Component | MoveType>;
   errors?: Record<string, string>;
+  plugins?: Array<(config: DubheConfig, projectDir: string) => Promise<void>>;
 };
 
 export type DubheMetadata = {

--- a/packages/sui-common/src/codegen/utils/renderMove/schemaGen.ts
+++ b/packages/sui-common/src/codegen/utils/renderMove/schemaGen.ts
@@ -82,6 +82,12 @@ export async function schemaGen(
     await generateSchemaError(config.name, config.errors, rootDir);
   }
 
+  if (config.plugins) {
+    for (const plugin of config.plugins) {
+      await plugin(config, rootDir);
+    }
+  }
+
   // await generateDefaultSchema(config, rootDir);
   // await generateInit(config, rootDir);
   await generateSystemsAndTests(config, rootDir);


### PR DESCRIPTION
Developers can add their own custom generate logic like this :

```json
......
export const dubheConfig = defineConfig({
  name: 'moonblock',
  description: 'moonblock contract',
  enums: {
    BlockType: ['grass', 'stone', 'water', 'tree']
  },
  plugins: [function custom(config: DubheConfig, projectpath: string) {}],
......
```

After you added this, when developer can run 
`pnpm dubhe schemagen`
His own custom generate logic will be executed. 